### PR TITLE
Convert leaderboard page to Flask/Jinja template

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -128,3 +128,30 @@ def friends_feed():
 @main.route('/password-reset')
 def password_reset():
     return render_template('password_reset.html')
+
+# ─── LEADERBOARD PAGE ───────────────────────────────────────
+@main.route('/leaderboard')
+def leaderboard():
+    return render_template(
+        'leaderboard-page.html',
+        overall_leaderboard=[
+            {"username": "UserA"},
+            {"username": "UserB"},
+            {"username": "UserC"}
+        ],
+        bench_leaderboard=[
+            {"username": "UserA", "weight_kg": 90},
+            {"username": "UserB", "weight_kg": 80},
+            {"username": "UserC", "weight_kg": 75}
+        ],
+        squat_leaderboard=[
+            {"username": "UserA", "weight_kg": 120},
+            {"username": "UserB", "weight_kg": 110},
+            {"username": "UserC", "weight_kg": 100}
+        ],
+        deadlift_leaderboard=[
+            {"username": "UserA", "weight_kg": 150},
+            {"username": "UserB", "weight_kg": 140},
+            {"username": "UserC", "weight_kg": 130}
+        ]
+    )

--- a/app/routes.py
+++ b/app/routes.py
@@ -131,6 +131,7 @@ def password_reset():
 
 # ─── LEADERBOARD PAGE ───────────────────────────────────────
 @main.route('/leaderboard')
+@login_required
 def leaderboard():
     return render_template(
         'leaderboard-page.html',

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -157,6 +157,15 @@ a:hover {
     margin-bottom: 1rem;
 }
 
+.section-title-lg {
+    font-size: 2rem;
+}
+
+.section-title-hd {
+    font-size: 3rem;
+}
+
+
 /* ── Bootstrap Form Overrides ── */
 .form-control,
 .form-select {
@@ -467,4 +476,38 @@ textarea.form-control {
     .topbar {
         padding: 0 1rem;
     }
+}
+
+/* ── Custom table ── */
+.custom-table {
+    --bs-table-bg: transparent;
+    --bs-table-striped-bg: transparent;
+    --bs-table-hover-bg: rgba(255, 255, 255, 0.06);
+    --bs-table-color: var(--color-text-muted);
+    --bs-table-striped-color: var(--color-text-muted);
+    --bs-table-hover-color: var(--color-text);
+}
+
+.custom-table th {
+    font-family: var(--font-display);
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid var(--color-border);
+    font-size: 0.9rem;
+    color: var(--color-text);
+    font-weight: 700;
+    background-color: transparent;
+}
+
+.custom-table td {
+    font-family: var(--font-body);
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid var(--color-border);
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+    background-color: transparent;
+}
+
+.custom-table tbody tr:hover td {
+    background-color: rgba(255, 255, 255, 0.06);
+    color: var(--color-text);
 }

--- a/app/templates/leaderboard-page.html
+++ b/app/templates/leaderboard-page.html
@@ -1,137 +1,62 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Leaderboard - GymTracker</title>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Leaderboard – FitTrack</title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Syne:wght@600;700;800&family=DM+Sans:wght@400;500&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
     </head>
 
-     <!--bootstrap css link-->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <!--css style sheet page link-->
-    <link rel="stylesheet" href="cssstyle sheet file name here">
-
     <body>
-        <!--navbar-->
-        <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-            <div class="container">
-                <a class="navbar-brand" href="welcome-page.html">GymTracker</a>
-                <button class="navbar-toggler" type="button"
-                    data-bs-toggle="collapse"
-                    data-bs-target="#mainNav"
-                    aria-controls="mainNav"
-                    aria-expanded="false"
-                    aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon"></span>
-                    </button>
+        <header class="topbar navbar">
+            <span class="topbar-title navbar-brand">FitTrack</span>
+            <span class="greeting ms-auto">Keep Going Strong <strong>{{ current_user.username }}</strong></span>
+            <a href="{{ url_for('main.logout') }}" class="btn btn-outline-secondary btn-sm ms-3">Logout</a>
+        </header>
 
-                    <div class="collapse navbar-collapse" id="mainNav">
-                        <ul class="navbar-nav ms-auto">
-                            <li class="nav-item">
-                                <a class="nav-link" href="dashboard.html">Dashboard</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="history-page.html"> History</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="friend-feed.html"> Friend Feed</a>
-                            </li>
-                             <li class="nav-item">
-                                <a class="nav-link" href="profile-page.html"> Profile</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="calories-page.html"> Calories</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="other_users_profile-page.html"> Friends</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="settings-page.html"> Settings</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link active" href="leaderboard-page.html"> Leaderboard</a>
-                            </li>
-
-                        </ul>
-                    </div>
-            </div>
-        </nav>
-
+        <main class="main container-fluid py-4">
         <!--leaderboard header-->
-        <section class="leaderboard-header pt-0 pb-5 text-left">
-            <div class="container">
-                <h1 class="display-4 fw-bold">Leaderboard</h1>
-                <p class="lead">Look to see how your progress compares to the rest!</p>
+        <section class="leaderboard-header">
+            <div class="container-fluid">
+                <h1 class="section-title section-title-hd">Leaderboard</h1>
+                <p class="section-title">Look to see how your progress compares to the rest!</p>
             </div>
         </section>
 
-
-        <main class="py-2">
             <div class="container">
 
                 <!-- Top leaderboard -->
                 <section class="mb-5">
-                    <div class="card shadow-sm">
+                    <div class="card app-card">
                         <div class="card-body">
-                            <h2 class="h3 text-center mb-3">Overall Leaderboard</h2>
-                            <p class="text-center text-muted">Top users across all tracked activity.</p>
-                            <ul class="list-group list-group-flush">
-                            <li class="list-group-item">1. User A</li>
-                            <li class="list-group-item">2. User B</li>
-                            <li class="list-group-item">3. User C</li>
-                    </ul>
+                            <h3 class="section-title section-title-lg text-center">Overall Leaderboard</h3>
+                            <p class="section-title text-center">Users across all tracked activity.</p>
+
+                            <ul class="cal-list">
+                                {% if overall_leaderboard %}
+                                    {% for user in overall_leaderboard %}
+                                        <li>{{ loop.index }}. {{ user.username }}</li>
+                                    {% endfor %}
+                                {% else %}
+                                    <li>No leaderboard data available yet.</li>
+                                {% endif %}
+                            </ul>
                         </div>
                     </div>
                 </section>
 
                 <!-- Three smaller leaderboards -->
                 <section>
-                    <div class="container">
-                        <div class="row g-4">
-                            <div class="col-md-4">
-                                <div class="card shadow-sm h-100">
-                                    <div class="card-body">
-                                        <h3 class="h4 text-center mb-3">Bench Press</h3>
-                                        <div class="table-responsive">
-                                            <table class="table table-striped table-hover text-center align-middle">
-                                                <thead class="table-dark">
-                                                    <tr>
-                                                        <th>Rank</th>
-                                                        <th>Username</th>
-                                                        <th>Weight</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    <tr>
-                                                        <td>1</td>
-                                                        <td>UserA</td>
-                                                        <td>90 kg</td>
-                                                    </tr>
-                                                    <tr>
-                                                        <td>2</td>
-                                                        <td>UserB</td>
-                                                        <td>80 kg</td>
-                                                    </tr>
-                                                    <tr>
-                                                        <td>3</td>
-                                                        <td>UserC</td>
-                                                        <td>75 kg</td>
-                                                    </tr>
-                                                </tbody>
-                                            </table>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
+                    <div class="row g-4">
                         <div class="col-md-4">
-                            <div class="card shadow-sm h-100">
+                            <div class="card app-card h-100">
                                 <div class="card-body">
-                                    <h3 class="h4 text-center mb-3">Squat</h3>
+                                    <h3 class="section-title section-title-lg text-center">Bench Press</h3>
                                     <div class="table-responsive">
-                                        <table class="table table-striped table-hover text-center align-middle">
-                                            <thead class="table-dark">
+                                        <table class="table text-center custom-table">
+                                            <thead>
                                                 <tr>
                                                     <th>Rank</th>
                                                     <th>Username</th>
@@ -139,21 +64,19 @@
                                                 </tr>
                                             </thead>
                                             <tbody>
-                                                <tr>
-                                                    <td>1</td>
-                                                    <td>UserA</td>
-                                                    <td>120 kg</td>
-                                                </tr>
-                                                <tr>
-                                                    <td>2</td>
-                                                    <td>UserB</td>
-                                                    <td>110 kg</td>
-                                                </tr>
-                                                <tr>
-                                                    <td>3</td>
-                                                    <td>UserC</td>
-                                                    <td>100 kg</td>
-                                                </tr>
+                                                {% if bench_leaderboard %}
+                                                    {% for entry in bench_leaderboard %}
+                                                        <tr>
+                                                            <td>{{ loop.index }}</td>
+                                                            <td>{{ entry.username }}</td>
+                                                            <td>{{ entry.weight_kg }} kg</td>
+                                                        </tr>
+                                                    {% endfor %}
+                                                {% else %}
+                                                    <tr>
+                                                        <td colspan="3">No bench press data available.</td>
+                                                    </tr>
+                                                {% endif %}
                                             </tbody>
                                         </table>
                                     </div>
@@ -161,38 +84,69 @@
                             </div>
                         </div>
 
-                        <div class="col-md-4">
-                            <div class="card shadow-sm h-100">
-                                <div class="card-body">
-                                    <h3 class="h4 text-center mb-3">Deadlift</h3>
-                                    <div class="table-responsive">
-                                        <table class="table table-striped table-hover text-center align-middle">
-                                            <thead class="table-dark">
+                     <div class="col-md-4">
+                        <div class="card app-card h-100">
+                            <div class="card-body">
+                                <h3 class="section-title section-title-lg text-center">Squat</h3>
+                                <div class="table-responsive">
+                                    <table class="table text-center custom-table">
+                                        <thead>
+                                            <tr>
+                                                <th>Rank</th>
+                                                <th>Username</th>
+                                                <th>Weight</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% if squat_leaderboard %}
+                                                {% for entry in squat_leaderboard %}
+                                                    <tr>
+                                                        <td>{{ loop.index }}</td>
+                                                        <td>{{ entry.username }}</td>
+                                                        <td>{{ entry.weight_kg }} kg</td>
+                                                    </tr>
+                                                {% endfor %}
+                                            {% else %}
                                                 <tr>
-                                                    <th>Rank</th>
-                                                    <th>Username</th>
-                                                    <th>Weight</th>
+                                                    <td colspan="3">No squat data available.</td>
                                                 </tr>
-                                            </thead>
-                                            <tbody>
+                                            {% endif %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="col-md-4">
+                        <div class="card app-card h-100">
+                            <div class="card-body">
+                                <h3 class="section-title section-title-lg text-center">Deadlift</h3>
+                                <div class="table-responsive">
+                                    <table class="table text-center custom-table">
+                                        <thead>
+                                            <tr>
+                                                <th>Rank</th>
+                                                <th>Username</th>
+                                                <th>Weight</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% if deadlift_leaderboard %}
+                                                {% for entry in deadlift_leaderboard %}
+                                                    <tr>
+                                                        <td>{{ loop.index }}</td>
+                                                        <td>{{ entry.username }}</td>
+                                                        <td>{{ entry.weight_kg }} kg</td>
+                                                    </tr>
+                                                {% endfor %}
+                                            {% else %}
                                                 <tr>
-                                                    <td>1</td>
-                                                    <td>UserA</td>
-                                                    <td>150 kg</td>
+                                                    <td colspan="3">No deadlift data available.</td>
                                                 </tr>
-                                                <tr>
-                                                    <td>2</td>
-                                                    <td>UserB</td>
-                                                    <td>140 kg</td>
-                                                </tr>
-                                                <tr>
-                                                    <td>3</td>
-                                                    <td>UserC</td>
-                                                    <td>130 kg</td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-                                    </div>
+                                            {% endif %}
+                                        </tbody>
+                                    </table>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Updated the leaderboard page by converting it from static HTML into a Flask/Jinja template and moving it into the app’s template structure. 

Added the leaderboard route and integrated template variables for the overall, bench press, squat, and deadlift leaderboards so the page can render Flask-provided data.

Updated the CSS to support the leaderboard layout, including the custom table styling and heading size variants used by the new template.