### PR TITLE
Added scroll functionality to leaderboards

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -671,3 +671,14 @@ textarea.form-control {
     font-size: 0.88rem;
     margin-bottom: 1rem;
 }
+
+/* ── Leaderboard Page ── */
+.leaderboard-list-scroll {
+    max-height: 220px;
+    overflow-y: auto;
+}
+
+.leaderboard-table-scroll {
+    max-height: 250px;
+    overflow-y: auto;
+}

--- a/app/templates/leaderboard-page.html
+++ b/app/templates/leaderboard-page.html
@@ -4,6 +4,8 @@
 
 {% block content %}
 
+<div class="leaderboard-page">
+
     <section class="leaderboard-header">
         <div class="container-fluid">
             <h1 class="section-title section-title-hd">Leaderboard</h1>
@@ -14,35 +16,37 @@
     <div class="container">
 
         <!-- Overall leaderboard -->
-        <section class="mb-5">
+        <section class="mb-3">
             <div class="card app-card">
                 <div class="card-body">
                     <h3 class="section-title section-title-lg text-center">Overall Leaderboard</h3>
                     <p class="section-title text-center">Users across all tracked activity.</p>
 
-                    <ul class="cal-list">
-                        {% if overall_leaderboard %}
-                            {% for user in overall_leaderboard %}
-                                <li>{{ loop.index }}. {{ user.username }}</li>
-                            {% endfor %}
-                        {% else %}
-                            <li>No leaderboard data available yet.</li>
-                        {% endif %}
-                    </ul>
+                    <div class="leaderboard-list-scroll">
+                        <ul class="cal-list mb-0">
+                            {% if overall_leaderboard %}
+                                {% for user in overall_leaderboard %}
+                                    <li>{{ loop.index }}. {{ user.username }}</li>
+                                {% endfor %}
+                            {% else %}
+                                <li>No leaderboard data available yet.</li>
+                            {% endif %}
+                        </ul>
+                    </div>
                 </div>
             </div>
         </section>
 
         <!-- Three smaller leaderboards -->
-        <section class="mb-5">
-            <div class="row g-4">
+        <section class="mb-3">
+            <div class="row g-3">
 
                 <div class="col-md-4">
                     <div class="card app-card h-100">
                         <div class="card-body">
                             <h3 class="section-title section-title-lg text-center">Bench Press</h3>
-                            <div class="table-responsive">
-                                <table class="table text-center custom-table">
+                            <div class="table-responsive leaderboard-table-scroll">
+                                <table class="table text-center custom-table mb-0">
                                     <thead>
                                         <tr>
                                             <th>Rank</th>
@@ -75,8 +79,8 @@
                     <div class="card app-card h-100">
                         <div class="card-body">
                             <h3 class="section-title section-title-lg text-center">Squat</h3>
-                            <div class="table-responsive">
-                                <table class="table text-center custom-table">
+                            <div class="table-responsive leaderboard-table-scroll">
+                                <table class="table text-center custom-table mb-0">
                                     <thead>
                                         <tr>
                                             <th>Rank</th>
@@ -109,8 +113,8 @@
                     <div class="card app-card h-100">
                         <div class="card-body">
                             <h3 class="section-title section-title-lg text-center">Deadlift</h3>
-                            <div class="table-responsive">
-                                <table class="table text-center custom-table">
+                            <div class="table-responsive leaderboard-table-scroll">
+                                <table class="table text-center custom-table mb-0">
                                     <thead>
                                         <tr>
                                             <th>Rank</th>
@@ -143,5 +147,7 @@
         </section>
 
     </div>
+
+</div>
 
 {% endblock %}


### PR DESCRIPTION
Added scroll functionality to the leaderboard page to improve formatting and make the layout more compact. This helps prevent the tables from becoming too long and taking up too much vertical space on the page.

Can be tweaked further to fit styling.