### PR TITLE
Welcome rework

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -12,7 +12,7 @@ main = Blueprint('main', __name__)
 def index():
     if current_user.is_authenticated:
         return redirect(url_for('main.dashboard'))
-    return redirect(url_for('main.login'))
+    return render_template('welcome-page.html')
 
 # ─── SIGNUP ─────────────────────────────────────────────
 @main.route('/signup', methods=['GET', 'POST'])

--- a/app/templates/welcome-page.html
+++ b/app/templates/welcome-page.html
@@ -14,35 +14,9 @@
 </head>
 <body>
 
-    <nav class="navbar navbar-expand-lg topbar">
+    <nav class="navbar topbar">
         <div class="container-fluid">
-            <a class="navbar-brand" href="welcome-page.html">FitTrack</a>
-
-            <button class="navbar-toggler" type="button"
-                    data-bs-toggle="collapse"
-                    data-bs-target="#mainNav"
-                    aria-controls="mainNav"
-                    aria-expanded="false"
-                    aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-
-            <div class="collapse navbar-collapse" id="mainNav">
-                <ul class="navbar-nav ms-auto">
-                    <li class="nav-item">
-                        <a class="nav-link active" href="welcome-page.html">Welcome</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="dashboard.html">Dashboard</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="history.html">History</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="friends_feed.html">Friend Feed</a>
-                    </li>
-                </ul>
-            </div>
+            <a class="navbar-brand topbar-title" href="{{ url_for('main.index') }}">FitTrack</a>
         </div>
     </nav>
 
@@ -58,8 +32,8 @@
                     </p>
 
                     <div class="d-flex justify-content-center gap-3 flex-wrap">
-                        <a href="login.html" class="btn btn-primary">Login</a>
-                        <a href="signup.html" class="btn btn-outline-primary">Sign Up</a>
+                        <a href="{{ url_for('main.login') }}" class="btn btn-primary">Login</a>
+                        <a href="{{ url_for('main.signup') }}" class="btn btn-outline-primary">Sign Up</a>
                     </div>
                 </div>
             </div>
@@ -67,5 +41,6 @@
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+
 </body>
 </html>


### PR DESCRIPTION
## Fix and wire up welcome page as public landing page

Closes #54 

### Summary
The welcome page has been reworked to function as the public landing page for the application. It is now the first thing a logged-out user sees when visiting the site, with logged-in users bypassed directly to the dashboard.

### Changes Made

**`routes.py`**
- Updated `/` index route to render `welcome-page.html` for logged-out users instead of redirecting to login
- Logged-in users are still redirected directly to the dashboard

**`welcome-page.html`**
- Moved file into `app/templates/` so Flask can serve it correctly
- Fixed CSS link to use `url_for('static', filename='styles.css')`
- Fixed all links to use `url_for` Flask routing instead of raw HTML file paths
- Stripped navbar down to brand logo only — logged-out users have no business navigating to protected pages
- Login and Signup buttons are the only call to action on the page

### Testing
- Verified that visiting `http://localhost:5000` shows the welcome page when not logged in
- Verified that visiting `http://localhost:5000` redirects to dashboard when already logged in
- Verified Login and Signup buttons navigate to the correct pages