### PR TITLE
fix: load jQuery in base.html so main.js shared helpers work

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -81,6 +81,9 @@
         {% block content %}{% endblock %}
     </main>
 
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+            integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
+            crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='main.js') }}"></script>
 


### PR DESCRIPTION
## Summary
- `main.js` uses jQuery (`$.ajax`, `$(document).ready`, `showToast`, etc.)
  but `base.html` never loaded jQuery, so every page threw
  `ReferenceError: $ is not defined` and no shared helpers ran.
- Adds the jQuery 3.7.1 CDN `<script>` tag to `base.html` before the
  Bootstrap bundle.

Closes #<issue number>.

## Test plan
- [ ] Open `/dashboard` in browser — console has no `$ is not defined` errors
- [ ] Trigger a flash message (e.g. failed login) — auto-hides after ~4s
- [ ] Active nav link is highlighted on each page
- [ ] Bootstrap tooltips/dropdowns still work