### PR TITLE
Fix app setup after merge by adding mail and migration dependencies

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,23 +2,44 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from flask_migrate import Migrate
+from flask_mail import Mail
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
 
 db = SQLAlchemy()
 login_manager = LoginManager()
 migrate = Migrate()
+mail = Mail()
+
 
 def create_app():
     app = Flask(__name__)
-    app.config['SECRET_KEY'] = 'your_secret_key'
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///fitness.db'
+
+    app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', 'dev-secret-key')
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DATABASE_URL', 'sqlite:///fitness.db')
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+    app.config['MAIL_SERVER'] = os.getenv('MAIL_SERVER')
+    app.config['MAIL_PORT'] = int(os.getenv('MAIL_PORT', 587))
+    app.config['MAIL_USE_TLS'] = os.getenv('MAIL_USE_TLS', 'true').lower() == 'true'
+    app.config['MAIL_USE_SSL'] = os.getenv('MAIL_USE_SSL', 'false').lower() == 'true'
+    app.config['MAIL_USERNAME'] = os.getenv('MAIL_USERNAME')
+    app.config['MAIL_PASSWORD'] = os.getenv('MAIL_PASSWORD')
+    app.config['MAIL_DEFAULT_SENDER'] = os.getenv(
+        'MAIL_DEFAULT_SENDER',
+        app.config['MAIL_USERNAME']
+    )
 
     db.init_app(app)
     login_manager.init_app(app)
     migrate.init_app(app, db)
+    mail.init_app(app)
+
     login_manager.login_view = 'main.login'
 
     from app import models
-
     from app.models import User
 
     @login_manager.user_loader


### PR DESCRIPTION
Fixed app setup issues after the recent merge.

After merging the latest changes, the database creation scripts stopped working because the app was trying to import new dependencies and objects that were not fully set up yet.

Changes made:

* Installed and added support for `Flask-Migrate`, which was required after migration support was introduced.
* Added `Flask-Mail` initialization in `app/__init__.py` so `routes.py` can correctly import `mail`.
* Updated the app factory to initialize `mail` alongside `db`, `login_manager`, and `migrate`.
* Added mail configuration from environment variables so the password reset email feature can work properly.
* Fixed the issue where `python create_db.py` failed before the database could be created.

Reason for changes:
The merge introduced code that depended on `flask_migrate` and `mail`, but the local environment and app factory were missing parts of that setup. This caused errors when running `create_db.py` and `seed.py`. These changes make sure the Flask app can start correctly and the database can be created again.
