### PR TITLE
Fix admin report and feedback counts

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -765,10 +765,17 @@ def admin():
         abort(403)
 
     users = User.query.order_by(User.created_at.desc()).all()
-    reports = Report.query.order_by(Report.created_at.desc()).all()
-    feedbacks = Feedback.query.order_by(Feedback.created_at.desc()).all()
 
-    return render_template('admin.html',
+    reports = Feedback.query.filter_by(type='report') \
+        .order_by(Feedback.created_at.desc()) \
+        .all()
+
+    feedbacks = Feedback.query.filter(Feedback.type != 'report') \
+        .order_by(Feedback.created_at.desc()) \
+        .all()
+
+    return render_template(
+        'admin.html',
         users=users,
         reports=reports,
         feedbacks=feedbacks


### PR DESCRIPTION
## Fix: Admin Report and Feedback Counts

### Summary
This update fixes an issue where user reports were being counted as feedback on the admin dashboard. As a result, the **Total Reports** count stayed at `0`, while the **Total Feedback** count increased incorrectly.

### Issue
Reports submitted through the feedback page were being stored in the `Feedback` table with `type="report"`. However, the admin route was trying to count reports from the separate `Report` table.

Because of this mismatch:
- Reports were not appearing in the reports count.
- Reports were being included in the feedback count.
- The admin dashboard totals were inaccurate.

### Changes Made
- Updated the admin route to query reports from the `Feedback` table where `type="report"`.
- Updated the feedback query to exclude records where `type="report"`.
- Ensured the admin dashboard now correctly separates:
  - Total Users
  - Total Reports
  - Total Feedback
- Confirmed no JavaScript changes were required because the admin page is rendered through Flask/Jinja.

### Reason for Change
This was a backend query issue rather than a frontend display issue. The admin template was displaying the data correctly, but the route was sending incorrectly grouped data.

These changes ensure that reports and feedback are counted and displayed separately on the admin dashboard.