### PR TITLE
Calories page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -590,6 +590,68 @@ def calories():
         current_day_index=current_day_index
     )
 
+# ─── CALORIES CHART DATA API ────────────────────────────
+@main.route('/api/calories-chart-data')
+@login_required
+def calories_chart_data():
+    today = date.today()
+
+    selected_week = request.args.get('week', 'this')
+    start_of_this_week = today - timedelta(days=today.weekday())
+
+    if selected_week == 'last':
+        week_start = start_of_this_week - timedelta(days=7)
+    elif selected_week == 'two_weeks_ago':
+        week_start = start_of_this_week - timedelta(days=14)
+    else:
+        selected_week = 'this'
+        week_start = start_of_this_week
+
+    week_end = week_start + timedelta(days=6)
+
+    week_labels = []
+    week_burned_data = []
+    week_consumed_data = []
+
+    today_index = today.weekday() if selected_week == 'this' else None
+    current_day_index = today.weekday() if selected_week == 'this' else None
+
+    for i in range(7):
+        day = week_start + timedelta(days=i)
+
+        week_labels.append(day.strftime('%a'))
+
+        # If viewing this week, do not draw future days
+        if selected_week == 'this' and day > today:
+            week_burned_data.append(None)
+            week_consumed_data.append(None)
+            continue
+
+        daily_workouts = Workout.query.filter_by(user_id=current_user.id).filter(
+            db.func.date(Workout.date) == day
+        ).all()
+
+        daily_meals = Meal.query.filter_by(user_id=current_user.id).filter(
+            db.func.date(Meal.date) == day
+        ).all()
+
+        daily_total_burned = sum(workout.calories_burned or 0 for workout in daily_workouts)
+        daily_total_consumed = sum(meal.calories or 0 for meal in daily_meals)
+
+        week_burned_data.append(daily_total_burned)
+        week_consumed_data.append(daily_total_consumed)
+
+    return jsonify({
+        'success': True,
+        'selectedWeek': selected_week,
+        'weekStart': week_start.strftime('%d %b'),
+        'weekEnd': week_end.strftime('%d %b'),
+        'labels': week_labels,
+        'burnedData': week_burned_data,
+        'consumedData': week_consumed_data,
+        'todayIndex': today_index,
+        'currentDayIndex': current_day_index
+    })
 
 # ─── ADD MEAL API ───────────────────────────────────────
 @main.route('/api/add-meal', methods=['POST'])

--- a/app/routes.py
+++ b/app/routes.py
@@ -534,13 +534,16 @@ def calories():
     else:
         selected_week = 'this'
         week_start = start_of_this_week
+    
+    current_day_index = today.weekday() if selected_week == 'this' else None
 
     week_end = week_start + timedelta(days=6)
 
     week_labels = []
     week_burned_data = []
     week_consumed_data = []
-    today_index = None
+
+    today_index = today.weekday() if selected_week == 'this' else None
 
     for i in range(7):
         day = week_start + timedelta(days=i)
@@ -567,8 +570,6 @@ def calories():
         week_burned_data.append(daily_total_burned)
         week_consumed_data.append(daily_total_consumed)
 
-    if selected_week == 'this' and today not in (week_start, week_end):
-        today_index = today.weekday()
 
     return render_template(
         'calories-page.html',
@@ -585,7 +586,8 @@ def calories():
         week_labels=week_labels,
         week_burned_data=week_burned_data,
         week_consumed_data=week_consumed_data,
-        today_index=today_index
+        today_index=today_index,
+        current_day_index=current_day_index
     )
 
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -539,6 +539,7 @@ def calories():
 
     week_labels = []
     week_burned_data = []
+    week_consumed_data = []
 
     for i in range(7):
         day = week_start + timedelta(days=i)
@@ -547,10 +548,16 @@ def calories():
             db.func.date(Workout.date) == day
         ).all()
 
+        daily_meals = Meal.query.filter_by(user_id=current_user.id).filter(
+            db.func.date(Meal.date) == day
+        ).all()
+
         daily_total_burned = sum(workout.calories_burned or 0 for workout in daily_workouts)
+        daily_total_consumed = sum(meal.calories or 0 for meal in daily_meals)
 
         week_labels.append(day.strftime('%a'))
         week_burned_data.append(daily_total_burned)
+        week_consumed_data.append(daily_total_consumed)
 
     return render_template(
         'calories-page.html',
@@ -565,7 +572,8 @@ def calories():
         week_start=week_start,
         week_end=week_end,
         week_labels=week_labels,
-        week_burned_data=week_burned_data
+        week_burned_data=week_burned_data,
+        week_consumed_data=week_consumed_data
     )
 
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -540,9 +540,18 @@ def calories():
     week_labels = []
     week_burned_data = []
     week_consumed_data = []
+    today_index = None
 
     for i in range(7):
         day = week_start + timedelta(days=i)
+
+        week_labels.append(day.strftime('%a'))
+
+        # If viewing this week, do not draw future days
+        if selected_week == 'this' and day > today:
+            week_burned_data.append(None)
+            week_consumed_data.append(None)
+            continue
 
         daily_workouts = Workout.query.filter_by(user_id=current_user.id).filter(
             db.func.date(Workout.date) == day
@@ -555,9 +564,11 @@ def calories():
         daily_total_burned = sum(workout.calories_burned or 0 for workout in daily_workouts)
         daily_total_consumed = sum(meal.calories or 0 for meal in daily_meals)
 
-        week_labels.append(day.strftime('%a'))
         week_burned_data.append(daily_total_burned)
         week_consumed_data.append(daily_total_consumed)
+
+    if selected_week == 'this' and today not in (week_start, week_end):
+        today_index = today.weekday()
 
     return render_template(
         'calories-page.html',
@@ -573,7 +584,8 @@ def calories():
         week_end=week_end,
         week_labels=week_labels,
         week_burned_data=week_burned_data,
-        week_consumed_data=week_consumed_data
+        week_consumed_data=week_consumed_data,
+        today_index=today_index
     )
 
 

--- a/app/static/calories.js
+++ b/app/static/calories.js
@@ -7,6 +7,34 @@ document.addEventListener('DOMContentLoaded', function () {
         return Number(value || 0).toFixed(1);
     }
 
+    function updateConsumedChartForToday(totalConsumed) {
+        if (!window.caloriesChart || !window.caloriesChartData) {
+            console.warn('Calories chart or chart data is missing.');
+            return;
+        }
+
+        const currentDayIndex = window.caloriesChartData.currentDayIndex;
+
+        if (currentDayIndex === null || currentDayIndex === undefined) {
+            console.warn('Current day index is missing. Chart will only update on This week.');
+            return;
+        }
+
+        const consumedDataset = window.caloriesChart.data.datasets.find(
+            dataset => dataset.label === 'Calories Consumed'
+        );
+
+        if (!consumedDataset) {
+            console.warn('Calories Consumed dataset could not be found.');
+            return;
+        }
+
+        consumedDataset.data[currentDayIndex] = Number(totalConsumed || 0);
+
+        window.caloriesChart.update();
+    }
+
+
     if (!addMealForm || !mealsTableBody) return;
 
     addMealForm.addEventListener('submit', function (event) {
@@ -81,6 +109,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 document.getElementById('table-total-carbs').textContent = `${formatNumber(totals.total_carbs)} g`;
                 document.getElementById('table-total-fats').textContent = `${formatNumber(totals.total_fats)} g`;
                 document.getElementById('table-total-water').textContent = `${formatNumber(totals.total_water_ml)} ml`;
+
+                // Update calories chart totals
+                updateConsumedChartForToday(totals.total_calories_consumed);
             }
 
             addMealForm.reset();
@@ -137,11 +168,13 @@ document.addEventListener('DOMContentLoaded', function () {
                 document.getElementById('net-calories').textContent = formatNumber(totals.net_calories);
 
                 document.getElementById('table-total-calories').textContent = `${formatNumber(totals.total_calories_consumed)} kcal`;
-                document.getElementById('table-total-calories').textContent = `${formatNumber(totals.total_calories_consumed)} kcal`;
                 document.getElementById('table-total-protein').textContent = `${formatNumber(totals.total_protein)} g`;
                 document.getElementById('table-total-carbs').textContent = `${formatNumber(totals.total_carbs)} g`;
                 document.getElementById('table-total-fats').textContent = `${formatNumber(totals.total_fats)} g`;
                 document.getElementById('table-total-water').textContent = `${formatNumber(totals.total_water_ml)} ml`;
+
+                // Update calories chart totals
+                updateConsumedChartForToday(totals.total_calories_consumed);
             }
         })
         .catch(error => {
@@ -203,7 +236,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     };
 
-    new Chart(caloriesChart, {
+    window.caloriesChart = new Chart(caloriesChart, {
         type: 'line',
         data: {
             labels: window.caloriesChartData.labels,

--- a/app/static/calories.js
+++ b/app/static/calories.js
@@ -299,4 +299,60 @@ document.addEventListener('DOMContentLoaded', function () {
         },
         plugins: [todayLinePlugin]
     });
+    
+// ─── AJAX WEEKLY CHART UPDATE ──────────────────────────
+    const weekSelector = document.getElementById('week');
+    const weeklyCaloriesTitle = document.getElementById('weekly-calories-title');
+
+    if (weekSelector) {
+        weekSelector.addEventListener('change', function () {
+            const selectedWeek = weekSelector.value;
+
+            fetch(`/api/calories-chart-data?week=${selectedWeek}`)
+                .then(response => response.json())
+                .then(data => {
+                    if (!data.success) {
+                        alert('Could not update calories chart.');
+                        return;
+                    }
+
+                    // Update stored chart data
+                    window.caloriesChartData.labels = data.labels;
+                    window.caloriesChartData.burnedData = data.burnedData;
+                    window.caloriesChartData.consumedData = data.consumedData;
+                    window.caloriesChartData.todayIndex = data.todayIndex;
+                    window.caloriesChartData.currentDayIndex = data.currentDayIndex;
+
+                    // Update Chart.js data
+                    window.caloriesChart.data.labels = data.labels;
+
+                    const burnedDataset = window.caloriesChart.data.datasets.find(
+                        dataset => dataset.label === 'Calories Burned'
+                    );
+
+                    const consumedDataset = window.caloriesChart.data.datasets.find(
+                        dataset => dataset.label === 'Calories Consumed'
+                    );
+
+                    if (burnedDataset) {
+                        burnedDataset.data = data.burnedData;
+                    }
+
+                    if (consumedDataset) {
+                        consumedDataset.data = data.consumedData;
+                    }
+
+                    // Update chart title
+                    if (weeklyCaloriesTitle) {
+                        weeklyCaloriesTitle.textContent = `Weekly Calories: ${data.weekStart} – ${data.weekEnd}`;
+                    }
+
+                    window.caloriesChart.update();
+                })
+                .catch(error => {
+                    console.error('Error updating calories chart:', error);
+                    alert('Something went wrong while updating the chart.');
+                });
+        });
+    }
 });

--- a/app/static/calories.js
+++ b/app/static/calories.js
@@ -171,8 +171,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const styles = getComputedStyle(document.documentElement);
 
-    const chartLineColor = styles.getPropertyValue('--chart-calories-line').trim();
-    const chartFillColor = styles.getPropertyValue('--chart-calories-fill').trim();
+    const burnedLineColor = styles.getPropertyValue('--chart-calories-line').trim();
+    const burnedFillColor = styles.getPropertyValue('--chart-calories-fill').trim();
+    const consumedLineColor = styles.getPropertyValue('--chart-consumed-line').trim();
+    const consumedFillColor = styles.getPropertyValue('--chart-consumed-fill').trim();
     const chartGridColor = styles.getPropertyValue('--chart-grid-line').trim();
     const chartTextColor = styles.getPropertyValue('--color-text').trim();
 
@@ -180,17 +182,30 @@ document.addEventListener('DOMContentLoaded', function () {
         type: 'line',
         data: {
             labels: window.caloriesChartData.labels,
-            datasets: [{
-                label: 'Calories Burned',
-                data: window.caloriesChartData.burnedData,
-                borderWidth: 2,
-                tension: 0,
-                fill: true,
-                backgroundColor: chartFillColor,
-                borderColor: chartLineColor,
-                pointBackgroundColor: chartLineColor,
-                pointBorderColor: chartLineColor
-            }]
+            datasets: [
+                {
+                    label: 'Calories Burned',
+                    data: window.caloriesChartData.burnedData,
+                    borderWidth: 2,
+                    tension: 0,
+                    fill: true,
+                    backgroundColor: burnedFillColor,
+                    borderColor: burnedLineColor,
+                    pointBackgroundColor: burnedLineColor,
+                    pointBorderColor: burnedLineColor
+                },
+                {
+                    label: 'Calories Consumed',
+                    data: window.caloriesChartData.consumedData,
+                    borderWidth: 2,
+                    tension: 0,
+                    fill: true,
+                    backgroundColor: consumedFillColor,
+                    borderColor: consumedLineColor,
+                    pointBackgroundColor: consumedLineColor,
+                    pointBorderColor: consumedLineColor
+                }
+            ]
         },
         options: {
             responsive: true,

--- a/app/static/calories.js
+++ b/app/static/calories.js
@@ -178,6 +178,31 @@ document.addEventListener('DOMContentLoaded', function () {
     const chartGridColor = styles.getPropertyValue('--chart-grid-line').trim();
     const chartTextColor = styles.getPropertyValue('--color-text').trim();
 
+    const todayLinePlugin = {
+        id: 'todayLine',
+        afterDraw(chart) {
+            const todayIndex = window.caloriesChartData.todayIndex;
+
+            if (todayIndex === null || todayIndex === undefined) return;
+
+            const xScale = chart.scales.x;
+            const chartArea = chart.chartArea;
+            const ctx = chart.ctx;
+
+            const x = xScale.getPixelForValue(todayIndex);
+
+            ctx.save();
+            ctx.beginPath();
+            ctx.moveTo(x, chartArea.top);
+            ctx.lineTo(x, chartArea.bottom);
+            ctx.lineWidth = 1;
+            ctx.setLineDash([6, 6]);
+            ctx.strokeStyle = 'rgba(255, 255, 255, 0.45)';
+            ctx.stroke();
+            ctx.restore();
+        }
+    };
+
     new Chart(caloriesChart, {
         type: 'line',
         data: {
@@ -189,6 +214,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     borderWidth: 2,
                     tension: 0,
                     fill: true,
+                    spanGaps: false,
                     backgroundColor: burnedFillColor,
                     borderColor: burnedLineColor,
                     pointBackgroundColor: burnedLineColor,
@@ -200,6 +226,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     borderWidth: 2,
                     tension: 0,
                     fill: true,
+                    spanGaps: false,
                     backgroundColor: consumedFillColor,
                     borderColor: consumedLineColor,
                     pointBackgroundColor: consumedLineColor,
@@ -236,6 +263,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     }
                 }
             }
-        }
+        },
+        plugins: [todayLinePlugin]
     });
 });

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -518,8 +518,10 @@ textarea.form-control {
 }
 
 :root {
-    --chart-calories-line: #3b8eea;
-    --chart-calories-fill: rgba(59, 142, 234, 0.15);
+    --chart-calories-line: #f5a623;
+    --chart-calories-fill: rgba(245, 166, 35, 0.15);
+    --chart-consumed-line: #3b8eea;
+    --chart-consumed-fill: rgba(59, 142, 234, 0.15);
     --chart-grid-line: rgba(255, 255, 255, 0.08);
 }
 

--- a/app/templates/calories-page.html
+++ b/app/templates/calories-page.html
@@ -259,7 +259,8 @@
         window.caloriesChartData = {
             labels: {{ week_labels | tojson }},
             burnedData: {{ week_burned_data | tojson }},
-            consumedData: {{ week_consumed_data | tojson }}
+            consumedData: {{ week_consumed_data | tojson }},
+            todayIndex: {{ today_index | tojson }}
         };
     </script>
 

--- a/app/templates/calories-page.html
+++ b/app/templates/calories-page.html
@@ -260,7 +260,8 @@
             labels: {{ week_labels | tojson }},
             burnedData: {{ week_burned_data | tojson }},
             consumedData: {{ week_consumed_data | tojson }},
-            todayIndex: {{ today_index | tojson }}
+            todayIndex: {{ today_index | tojson }},
+            currentDayIndex: {{ current_day_index | tojson }}
         };
     </script>
 

--- a/app/templates/calories-page.html
+++ b/app/templates/calories-page.html
@@ -227,14 +227,14 @@
         <section class="mb-4">
             <div class="card app-card h-100 text-center">
                 <div class="card-body">
-                    <h2 class="section-title section-title-lg text-center">
+                    <h2 id="weekly-calories-title" class="section-title section-title-lg text-center">
                         Weekly Calories: {{ week_start.strftime('%d %b') }} – {{ week_end.strftime('%d %b') }}
                     </h2>
 
                     <form method="GET" action="{{ url_for('main.calories') }}" class="mb-3">
                         <label for="week" class="form-label">Select week</label>
 
-                        <select name="week" id="week" class="form-select" onchange="this.form.submit()">
+                        <select name="week" id="week" class="form-select">
                             <option value="this" {% if selected_week == 'this' %}selected{% endif %}>This week</option>
                             <option value="last" {% if selected_week == 'last' %}selected{% endif %}>Last week</option>
                             <option value="two_weeks_ago" {% if selected_week == 'two_weeks_ago' %}selected{% endif %}>Two weeks ago</option>

--- a/app/templates/calories-page.html
+++ b/app/templates/calories-page.html
@@ -228,7 +228,7 @@
             <div class="card app-card h-100 text-center">
                 <div class="card-body">
                     <h2 class="section-title section-title-lg text-center">
-                        Calories Burnt: {{ week_start.strftime('%d %b') }} – {{ week_end.strftime('%d %b') }}
+                        Weekly Calories: {{ week_start.strftime('%d %b') }} – {{ week_end.strftime('%d %b') }}
                     </h2>
 
                     <form method="GET" action="{{ url_for('main.calories') }}" class="mb-3">
@@ -252,13 +252,14 @@
 {% endblock %}
 
 {% block extra_scripts %}
-    <!-- Calories Burnt Graph -->
+    <!-- Weekly Calories Chart -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
     <script>
         window.caloriesChartData = {
             labels: {{ week_labels | tojson }},
-            burnedData: {{ week_burned_data | tojson }}
+            burnedData: {{ week_burned_data | tojson }},
+            consumedData: {{ week_consumed_data | tojson }}
         };
     </script>
 

--- a/app/templates/calories-page.html
+++ b/app/templates/calories-page.html
@@ -9,7 +9,7 @@
         <div class="container-fluid">
             <h1 class="section-title section-title-hd">Calories</h1>
             <p class="section-title">
-                Keep track of your calories, meals and daily goals. <strong>{{ current_user.username }}</strong>
+                Keep track of your calories, meals and daily goals.
             </p>
         </div>
     </section>
@@ -168,7 +168,7 @@
                                     <th>Carbs</th>
                                     <th>Fats</th>
                                     <th>Water</th>
-                                    <th>Action</th>
+                                    <th></th>
                                 </tr>
                             </thead>
                             <tbody id="meals-table-body">


### PR DESCRIPTION
Updated the calories page chart functionality so it now displays both calories burned and calories consumed, and updates dynamically without requiring a full page reload.

## Changes made

- Added weekly calories consumed data to the calories page.
- Updated the weekly calories chart to show both:
  - Calories burned from workout records.
  - Calories consumed from meal records.
- Updated the chart title from `Calories Burnt` to `Weekly Calories` to better reflect the two datasets.
- Swapped the chart colours so calories burned is shown in orange and calories consumed is shown in blue.
- Added logic so the current week chart only displays data up to the current day.
- Prevented future days in the current week from being drawn on the chart.
- Added a dotted vertical line to mark the current day on the chart.
- Added `currentDayIndex` to the chart data so today’s consumed calories point can be updated dynamically.
- Updated the chart after adding a meal without needing to reload the page.
- Updated the chart after deleting a meal without needing to reload the page.
- Added a new `/api/calories-chart-data` route to return weekly chart data as JSON.
- Updated the week selector so switching between this week, last week, and two weeks ago updates the chart using AJAX.
- Removed the week selector’s full page reload behaviour.
- Updated the weekly chart title dynamically when the selected week changes.
- Kept the calories AJAX API routes in `routes.py` alongside the related calories page route for now.

## Testing

- Verified that the weekly chart displays calories burned from workout records.
- Verified that the weekly chart displays calories consumed from meal records.
- Verified that calories burned and calories consumed appear as separate chart lines.
- Verified that the chart colours clearly distinguish calories burned and calories consumed.
- Verified that the dotted current-day line appears on the chart for the current week.
- Verified that adding a meal updates today’s calories consumed total on the chart without a page reload.
- Verified that deleting a meal updates today’s calories consumed total on the chart without a page reload.
- Verified that switching to last week updates the chart without refreshing the page.
- Verified that switching to two weeks ago updates the chart without refreshing the page.
- Verified that switching back to this week restores the current week chart data.
- Verified that the chart title updates when changing the selected week.
- Verified that adding or deleting a meal only updates the chart when viewing this week, since new meal changes apply to today.

## Notes

- The calories chart now uses AJAX for week changes instead of reloading the page.
- Adding or deleting meals only updates the current week chart because those actions affect today’s meal data.
- The calories AJAX API routes are currently kept in `routes.py` alongside the related calories page route. If the number of API routes grows further, these could be moved into a separate API blueprint for better organisation.
#26 