### PR TITLE
feat: filter, sort, delete-modal on history + search & sortable leaderboard

### DIFF
--- a/app/static/js/history.js
+++ b/app/static/js/history.js
@@ -1,0 +1,80 @@
+/**
+ * history.js
+ * Client-side filter, sort, and delete-confirm modal for the workout history page.
+ */
+
+(function () {
+    'use strict';
+
+    const list        = document.getElementById('workout-list');
+    const filterEl    = document.getElementById('history-filter');
+    const sortEl      = document.getElementById('history-sort');
+    const noResultsEl = document.getElementById('history-no-results');
+    const modalEl     = document.getElementById('deleteWorkoutModal');
+
+    if (!list) return;
+
+    const cards = Array.from(list.querySelectorAll('.workout-item-card'));
+
+    /* ── Filter ───────────────────────────────────────────── */
+    const applyFilter = () => {
+        const term = (filterEl.value || '').trim().toLowerCase();
+        let visibleCount = 0;
+
+        cards.forEach((card) => {
+            const title = card.dataset.title || '';
+            const matches = !term || title.includes(term);
+            card.hidden = !matches;
+            if (matches) visibleCount += 1;
+        });
+
+        if (noResultsEl) noResultsEl.hidden = visibleCount !== 0;
+    };
+
+    /* ── Sort ─────────────────────────────────────────────── */
+    const numericAttr = (el, name) => {
+        const n = parseFloat(el.dataset[name]);
+        return Number.isNaN(n) ? 0 : n;
+    };
+
+    const sorters = {
+        'date-desc':     (a, b) => (a.dataset.date < b.dataset.date ? 1 : -1),
+        'date-asc':      (a, b) => (a.dataset.date > b.dataset.date ? 1 : -1),
+        'duration-desc': (a, b) => numericAttr(b, 'duration') - numericAttr(a, 'duration'),
+        'calories-desc': (a, b) => numericAttr(b, 'calories') - numericAttr(a, 'calories'),
+        'title-asc':     (a, b) => (a.dataset.title > b.dataset.title ? 1 : -1)
+    };
+
+    const applySort = () => {
+        const key = sortEl.value;
+        const sorter = sorters[key];
+        if (!sorter) return;
+
+        const sorted = cards.slice().sort(sorter);
+        sorted.forEach((card) => list.appendChild(card));
+    };
+
+    if (filterEl) {
+        filterEl.addEventListener('input', applyFilter);
+    }
+    if (sortEl) {
+        sortEl.addEventListener('change', applySort);
+    }
+
+    /* ── Delete confirm modal ─────────────────────────────── */
+    if (modalEl) {
+        const titleEl   = modalEl.querySelector('#delete-workout-title');
+        const confirmEl = modalEl.querySelector('#delete-workout-confirm');
+
+        modalEl.addEventListener('show.bs.modal', (event) => {
+            const trigger = event.relatedTarget;
+            if (!trigger) return;
+
+            const url   = trigger.getAttribute('data-delete-url');
+            const title = trigger.getAttribute('data-workout-title');
+
+            if (confirmEl && url) confirmEl.setAttribute('href', url);
+            if (titleEl && title) titleEl.textContent = '"' + title + '"';
+        });
+    }
+}());

--- a/app/static/js/leaderboard.js
+++ b/app/static/js/leaderboard.js
@@ -1,0 +1,141 @@
+/**
+ * leaderboard.js
+ * - Global username filter across the overall list and the three lift tables.
+ * - Click-to-sort column headers on each lift table (rank / username / weight).
+ * - Highlights the current user's rows.
+ */
+
+(function () {
+    'use strict';
+
+    const page = document.querySelector('.leaderboard-page');
+    if (!page) return;
+
+    const currentUsername = (page.dataset.currentUsername || '').toLowerCase();
+    const filterEl        = document.getElementById('leaderboard-filter');
+    const overallList     = document.getElementById('overall-leaderboard');
+    const tables          = Array.from(document.querySelectorAll('.js-sortable-leaderboard'));
+
+    /* ── Highlight current user on initial render ────────── */
+    const highlightCurrentUser = () => {
+        if (!currentUsername) return;
+
+        if (overallList) {
+            overallList.querySelectorAll('li[data-username]').forEach((li) => {
+                if (li.dataset.username === currentUsername) {
+                    li.classList.add('is-current-user');
+                }
+            });
+        }
+
+        tables.forEach((table) => {
+            table.querySelectorAll('tbody tr[data-username]').forEach((tr) => {
+                if (tr.dataset.username === currentUsername) {
+                    tr.classList.add('is-current-user');
+                }
+            });
+        });
+    };
+
+    /* ── Filter across all leaderboards ──────────────────── */
+    const applyFilter = () => {
+        const term = (filterEl.value || '').trim().toLowerCase();
+
+        if (overallList) {
+            const items = overallList.querySelectorAll('li[data-username]');
+            let visible = 0;
+            items.forEach((li) => {
+                const matches = !term || (li.dataset.username || '').includes(term);
+                li.hidden = !matches;
+                if (matches) visible += 1;
+            });
+            const noResults = overallList.parentElement.querySelector('.leaderboard-no-results');
+            if (noResults && items.length > 0) {
+                noResults.hidden = visible !== 0;
+            }
+        }
+
+        tables.forEach((table) => {
+            const rows = table.querySelectorAll('tbody tr[data-username]');
+            let visible = 0;
+            rows.forEach((tr) => {
+                const matches = !term || (tr.dataset.username || '').includes(term);
+                tr.hidden = !matches;
+                if (matches) visible += 1;
+            });
+            const noResultsRow = table.querySelector('.leaderboard-no-results-row');
+            if (noResultsRow && rows.length > 0) {
+                noResultsRow.hidden = visible !== 0;
+            }
+        });
+    };
+
+    if (filterEl) {
+        filterEl.addEventListener('input', applyFilter);
+    }
+
+    /* ── Sortable column headers ─────────────────────────── */
+    const sortValue = (tr, key, type) => {
+        if (key === 'username') {
+            return (tr.dataset.username || '').toLowerCase();
+        }
+        const raw = tr.dataset[key];
+        if (type === 'number') {
+            const n = parseFloat(raw);
+            return Number.isNaN(n) ? 0 : n;
+        }
+        return (raw || '').toString().toLowerCase();
+    };
+
+    const sortTable = (table, key, type, direction) => {
+        const tbody = table.querySelector('tbody');
+        if (!tbody) return;
+
+        const dataRows = Array.from(tbody.querySelectorAll('tr[data-username]'));
+        const pinnedRows = Array.from(tbody.querySelectorAll('tr:not([data-username])'));
+
+        const factor = direction === 'asc' ? 1 : -1;
+
+        dataRows.sort((a, b) => {
+            const va = sortValue(a, key, type);
+            const vb = sortValue(b, key, type);
+            if (va < vb) return -1 * factor;
+            if (va > vb) return  1 * factor;
+            return 0;
+        });
+
+        dataRows.forEach((tr) => tbody.appendChild(tr));
+        pinnedRows.forEach((tr) => tbody.appendChild(tr));
+    };
+
+    const setHeaderState = (table, activeTh, direction) => {
+        table.querySelectorAll('.js-sort').forEach((th) => {
+            th.classList.remove('sort-asc', 'sort-desc');
+            th.setAttribute('aria-sort', 'none');
+        });
+        activeTh.classList.add(direction === 'asc' ? 'sort-asc' : 'sort-desc');
+        activeTh.setAttribute('aria-sort', direction === 'asc' ? 'ascending' : 'descending');
+    };
+
+    tables.forEach((table) => {
+        table.querySelectorAll('.js-sort').forEach((th) => {
+            th.setAttribute('tabindex', '0');
+            th.addEventListener('click', () => {
+                const key  = th.dataset.sortKey;
+                const type = th.dataset.sortType || 'string';
+                const currentlyAsc = th.classList.contains('sort-asc');
+                const direction = currentlyAsc ? 'desc' : 'asc';
+                sortTable(table, key, type, direction);
+                setHeaderState(table, th, direction);
+            });
+            th.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    th.click();
+                }
+            });
+        });
+    });
+
+    highlightCurrentUser();
+}());

--- a/app/templates/history.html
+++ b/app/templates/history.html
@@ -2,6 +2,45 @@
 
 {% block title %}Workout History – FitTrack{% endblock %}
 
+{% block extra_styles %}
+<style>
+    #deleteWorkoutModal .modal-content {
+        background-color: var(--color-surface);
+        color: var(--color-text);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        box-shadow: var(--shadow-card);
+    }
+
+    #deleteWorkoutModal .modal-header,
+    #deleteWorkoutModal .modal-footer {
+        border-color: var(--color-border);
+    }
+
+    #deleteWorkoutModal .modal-title {
+        font-family: var(--font-display);
+        color: var(--color-text);
+    }
+
+    #deleteWorkoutModal .modal-body {
+        color: var(--color-text-muted);
+    }
+
+    #deleteWorkoutModal .modal-body strong {
+        color: var(--color-text);
+    }
+
+    #deleteWorkoutModal .btn-close {
+        filter: invert(1) grayscale(100%) brightness(2);
+        opacity: 0.7;
+    }
+
+    #deleteWorkoutModal .btn-close:hover {
+        opacity: 1;
+    }
+</style>
+{% endblock %}
+
 {% block content %}
 
     <div class="row g-4 mb-4">
@@ -38,7 +77,7 @@
 
     <section class="card app-card workout-history-card mb-4">
         <div class="card-body">
-            <div class="d-flex justify-content-between align-items-center mb-4">
+            <div class="d-flex justify-content-between align-items-center mb-3">
                 <h2 class="section-title mb-0">Your Workouts</h2>
                 <a href="{{ url_for('main.start_workout') }}" class="btn btn-primary btn-sm">
                     <span>+ New Workout</span>
@@ -46,9 +85,31 @@
             </div>
 
             {% if workouts %}
-                <div class="workout-list">
+                <div class="row g-2 mb-3" id="history-toolbar">
+                    <div class="col-md-7">
+                        <label for="history-filter" class="visually-hidden">Filter by title</label>
+                        <input type="text" id="history-filter" class="form-control form-control-sm"
+                               placeholder="Filter by workout title…" aria-label="Filter by workout title">
+                    </div>
+                    <div class="col-md-5">
+                        <label for="history-sort" class="visually-hidden">Sort workouts</label>
+                        <select id="history-sort" class="form-select form-select-sm" aria-label="Sort workouts">
+                            <option value="date-desc">Newest first</option>
+                            <option value="date-asc">Oldest first</option>
+                            <option value="duration-desc">Longest duration</option>
+                            <option value="calories-desc">Most calories burned</option>
+                            <option value="title-asc">Title (A–Z)</option>
+                        </select>
+                    </div>
+                </div>
+
+                <div class="workout-list" id="workout-list">
                     {% for workout in workouts %}
-                        <div class="workout-item-card mb-3">
+                        <div class="workout-item-card mb-3"
+                             data-title="{{ workout.title|lower }}"
+                             data-date="{{ workout.date.isoformat() }}"
+                             data-duration="{{ workout.duration_mins or 0 }}"
+                             data-calories="{{ (workout.calories_burned or 0)|int }}">
                             <div class="row align-items-center">
                                 <div class="col-md-6">
                                     <h4 class="workout-title">{{ workout.title }}</h4>
@@ -86,11 +147,14 @@
                                             </span>
                                         </div>
 
-                                        <a href="{{ url_for('main.delete_workout', workout_id=workout.id) }}"
-                                           class="btn btn-outline-danger btn-sm"
-                                           onclick="return confirm('Are you sure you want to delete this workout?');">
-                                           Delete
-                                        </a>
+                                        <button type="button"
+                                                class="btn btn-outline-danger btn-sm js-delete-workout"
+                                                data-bs-toggle="modal"
+                                                data-bs-target="#deleteWorkoutModal"
+                                                data-workout-title="{{ workout.title }}"
+                                                data-delete-url="{{ url_for('main.delete_workout', workout_id=workout.id) }}">
+                                            Delete
+                                        </button>
                                     </div>
                                 </div>
                             </div>
@@ -121,6 +185,10 @@
                         </div>
                     {% endfor %}
                 </div>
+
+                <p id="history-no-results" class="text-muted text-center py-3 mb-0" hidden>
+                    No workouts match your filter.
+                </p>
             {% else %}
                 <div class="empty-state text-center py-5">
                     <p class="text-muted mb-3">No workouts logged yet.</p>
@@ -139,4 +207,30 @@
         </div>
     </div>
 
+    <!-- Delete confirmation modal -->
+    <div class="modal fade" id="deleteWorkoutModal" tabindex="-1"
+         aria-labelledby="deleteWorkoutModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="deleteWorkoutModalLabel">Delete workout?</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    Are you sure you want to permanently delete
+                    <strong id="delete-workout-title">this workout</strong>?
+                    This cannot be undone.
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <a id="delete-workout-confirm" href="#" class="btn btn-danger">Delete</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="{{ url_for('static', filename='js/history.js') }}"></script>
 {% endblock %}

--- a/app/templates/leaderboard-page.html
+++ b/app/templates/leaderboard-page.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-<div class="leaderboard-page">
+<div class="leaderboard-page" data-current-username="{{ current_user.username|lower }}">
 
     <section class="leaderboard-header">
         <div class="container-fluid">
@@ -15,6 +15,14 @@
 
     <div class="container">
 
+        <!-- Search bar -->
+        <section class="mb-3">
+            <label for="leaderboard-filter" class="visually-hidden">Search users</label>
+            <input type="text" id="leaderboard-filter" class="form-control"
+                   placeholder="Search users across all leaderboards…"
+                   aria-label="Search users across all leaderboards">
+        </section>
+
         <!-- Overall leaderboard -->
         <section class="mb-3">
             <div class="card app-card">
@@ -23,15 +31,18 @@
                     <p class="section-title text-center">Users across all tracked activity.</p>
 
                     <div class="leaderboard-list-scroll">
-                        <ul class="cal-list mb-0">
+                        <ul class="cal-list mb-0" id="overall-leaderboard">
                             {% if overall_leaderboard %}
                                 {% for user in overall_leaderboard %}
-                                    <li>{{ loop.index }}. {{ user.username }}</li>
+                                    <li data-username="{{ user.username|lower }}">{{ loop.index }}. {{ user.username }}</li>
                                 {% endfor %}
                             {% else %}
-                                <li>No leaderboard data available yet.</li>
+                                <li class="leaderboard-empty">No leaderboard data available yet.</li>
                             {% endif %}
                         </ul>
+                        <p class="leaderboard-no-results text-muted text-center mb-0 mt-2" hidden>
+                            No matching users.
+                        </p>
                     </div>
                 </div>
             </div>
@@ -46,28 +57,33 @@
                         <div class="card-body">
                             <h3 class="section-title section-title-lg text-center">Bench Press</h3>
                             <div class="table-responsive leaderboard-table-scroll">
-                                <table class="table text-center custom-table mb-0">
+                                <table class="table text-center custom-table mb-0 js-sortable-leaderboard">
                                     <thead>
                                         <tr>
-                                            <th>Rank</th>
-                                            <th>Username</th>
-                                            <th>Weight</th>
+                                            <th class="js-sort" data-sort-key="rank" data-sort-type="number" role="button">Rank</th>
+                                            <th class="js-sort" data-sort-key="username" data-sort-type="string" role="button">Username</th>
+                                            <th class="js-sort" data-sort-key="weight" data-sort-type="number" role="button">Weight</th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         {% if bench_leaderboard %}
                                             {% for entry in bench_leaderboard %}
-                                                <tr>
-                                                    <td>{{ loop.index }}</td>
+                                                <tr data-username="{{ entry.username|lower }}"
+                                                    data-rank="{{ loop.index }}"
+                                                    data-weight="{{ entry.weight_kg or 0 }}">
+                                                    <td class="js-rank">{{ loop.index }}</td>
                                                     <td>{{ entry.username }}</td>
                                                     <td>{{ entry.weight_kg }} kg</td>
                                                 </tr>
                                             {% endfor %}
                                         {% else %}
-                                            <tr>
+                                            <tr class="leaderboard-empty-row">
                                                 <td colspan="3">No bench press data available.</td>
                                             </tr>
                                         {% endif %}
+                                        <tr class="leaderboard-no-results-row" hidden>
+                                            <td colspan="3" class="text-muted">No matching users.</td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </div>
@@ -80,28 +96,33 @@
                         <div class="card-body">
                             <h3 class="section-title section-title-lg text-center">Squat</h3>
                             <div class="table-responsive leaderboard-table-scroll">
-                                <table class="table text-center custom-table mb-0">
+                                <table class="table text-center custom-table mb-0 js-sortable-leaderboard">
                                     <thead>
                                         <tr>
-                                            <th>Rank</th>
-                                            <th>Username</th>
-                                            <th>Weight</th>
+                                            <th class="js-sort" data-sort-key="rank" data-sort-type="number" role="button">Rank</th>
+                                            <th class="js-sort" data-sort-key="username" data-sort-type="string" role="button">Username</th>
+                                            <th class="js-sort" data-sort-key="weight" data-sort-type="number" role="button">Weight</th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         {% if squat_leaderboard %}
                                             {% for entry in squat_leaderboard %}
-                                                <tr>
-                                                    <td>{{ loop.index }}</td>
+                                                <tr data-username="{{ entry.username|lower }}"
+                                                    data-rank="{{ loop.index }}"
+                                                    data-weight="{{ entry.weight_kg or 0 }}">
+                                                    <td class="js-rank">{{ loop.index }}</td>
                                                     <td>{{ entry.username }}</td>
                                                     <td>{{ entry.weight_kg }} kg</td>
                                                 </tr>
                                             {% endfor %}
                                         {% else %}
-                                            <tr>
+                                            <tr class="leaderboard-empty-row">
                                                 <td colspan="3">No squat data available.</td>
                                             </tr>
                                         {% endif %}
+                                        <tr class="leaderboard-no-results-row" hidden>
+                                            <td colspan="3" class="text-muted">No matching users.</td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </div>
@@ -114,28 +135,33 @@
                         <div class="card-body">
                             <h3 class="section-title section-title-lg text-center">Deadlift</h3>
                             <div class="table-responsive leaderboard-table-scroll">
-                                <table class="table text-center custom-table mb-0">
+                                <table class="table text-center custom-table mb-0 js-sortable-leaderboard">
                                     <thead>
                                         <tr>
-                                            <th>Rank</th>
-                                            <th>Username</th>
-                                            <th>Weight</th>
+                                            <th class="js-sort" data-sort-key="rank" data-sort-type="number" role="button">Rank</th>
+                                            <th class="js-sort" data-sort-key="username" data-sort-type="string" role="button">Username</th>
+                                            <th class="js-sort" data-sort-key="weight" data-sort-type="number" role="button">Weight</th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         {% if deadlift_leaderboard %}
                                             {% for entry in deadlift_leaderboard %}
-                                                <tr>
-                                                    <td>{{ loop.index }}</td>
+                                                <tr data-username="{{ entry.username|lower }}"
+                                                    data-rank="{{ loop.index }}"
+                                                    data-weight="{{ entry.weight_kg or 0 }}">
+                                                    <td class="js-rank">{{ loop.index }}</td>
                                                     <td>{{ entry.username }}</td>
                                                     <td>{{ entry.weight_kg }} kg</td>
                                                 </tr>
                                             {% endfor %}
                                         {% else %}
-                                            <tr>
+                                            <tr class="leaderboard-empty-row">
                                                 <td colspan="3">No deadlift data available.</td>
                                             </tr>
                                         {% endif %}
+                                        <tr class="leaderboard-no-results-row" hidden>
+                                            <td colspan="3" class="text-muted">No matching users.</td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </div>
@@ -150,4 +176,30 @@
 
 </div>
 
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .js-sort {
+        cursor: pointer;
+        user-select: none;
+        white-space: nowrap;
+    }
+    .js-sort::after {
+        content: ' ';
+        opacity: 0.4;
+        margin-left: 0.25rem;
+    }
+    .js-sort.sort-asc::after  { content: '▲'; opacity: 1; }
+    .js-sort.sort-desc::after { content: '▼'; opacity: 1; }
+
+    .is-current-user {
+        font-weight: 700;
+        background-color: var(--color-primary-glow, rgba(13, 110, 253, 0.12));
+    }
+</style>
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="{{ url_for('static', filename='js/leaderboard.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- `history.html` now has a title filter, a sort dropdown (newest / oldest / longest / most calories / A–Z), and a themed Bootstrap confirm modal that replaces the native `confirm()` popup on Delete.
- `leaderboard-page.html` has a global username search and click-to-sort column headers across the three lift tables. The logged-in user's rows are highlighted.
- No backend changes — all sort/filter is client-side using `data-*` attributes.

## Changes
**`app/templates/history.html`**
- Toolbar with filter input + sort `<select>`
- `data-title / data-date / data-duration / data-calories` on every workout card
- Delete buttons now trigger `#deleteWorkoutModal`
- Themed modal styles (matches dark theme)
- Loads `history.js`

**`app/static/js/history.js`** *(new)*
- Real-time filter, multi-key sort, modal `show.bs.modal` handler

**`app/templates/leaderboard-page.html`**
- Search input
- Sortable `<th>` (rank/username/weight) with ▲▼ indicators
- `data-username / data-rank / data-weight` on rows
- Highlight class for current user
- Loads `leaderboard.js`

**`app/static/js/leaderboard.js`** *(new)*
- Single search filters all four leaderboards
- Click headers to toggle asc/desc sort
- Keyboard accessible (Tab + Enter)
- Highlights logged-in user

## Test plan
- [ ] `/history` — filter narrows results; "No workouts match your filter." appears when empty
- [ ] `/history` — each sort option reorders cards
- [ ] `/history` — delete modal opens with workout title; matches dark theme
- [ ] `/leaderboard` — search filters all four lists at once
- [ ] `/leaderboard` — clicking headers toggles asc/desc with arrow
- [ ] `/leaderboard` — current user's row is highlighted
- [ ] No console errors on either page