### PR TITLE
fixed the achievement bug by adding the missing import into routes.py

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -9,6 +9,7 @@ import hmac
 
 from app import db, mail
 from app.models import User, Workout, Meal, Achievement, Exercise, Feedback, Goal, Report, Comment, FeedPost, FeedPostComment, Friendship
+from app.achievements import check_and_award_achievements
 
 
 main = Blueprint('main', __name__)


### PR DESCRIPTION
# Fix: Import `check_and_award_achievements` in `routes.py`

## Summary

Adds the missing import for `check_and_award_achievements` from `app.achievements` in `app/routes.py`.

Closes #105

## What was wrong

`check_and_award_achievements` was being called inside `workout_finish` but was never imported, causing a `NameError` crash for every user attempting to finish a workout.

## Changes

- `app/routes.py` — added `from app.achievements import check_and_award_achievements`

## Testing

Manually verify by starting and finishing a workout — the user should be redirected to their profile with a success flash message, and any newly earned achievements should appear.

<img width="1467" height="480" alt="image" src="https://github.com/user-attachments/assets/bd2f2c45-7d80-42da-9f7b-d7409b5e3101" />

