### PR TITLE
Other user profile

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1608,3 +1608,30 @@ def api_edit_profile():
 
     db.session.commit()
     return jsonify({'success': True, 'message': 'Profile updated successfully.'})
+
+# ─── OTHER USER PROFILE ─────────────────────────────────
+@main.route('/user/<int:user_id>')
+@login_required
+def user_profile(user_id):
+    # Redirect to own profile if the user clicks their own name
+    if user_id == current_user.id:
+        return redirect(url_for('main.profile'))
+
+    user = User.query.get_or_404(user_id)
+
+    public_workouts = Workout.query.filter_by(
+        user_id=user_id,
+        is_public=True
+    ).order_by(Workout.date.desc()).all()
+
+    achievements = Achievement.query.filter_by(user_id=user_id).all()
+
+    total_calories_burned = sum(w.calories_burned or 0 for w in public_workouts)
+
+    return render_template(
+        'user_profile.html',
+        user=user,
+        workouts=public_workouts,
+        achievements=achievements,
+        total_calories_burned=total_calories_burned
+    )

--- a/app/templates/friends_feed.html
+++ b/app/templates/friends_feed.html
@@ -33,7 +33,9 @@
                 <div class="card-body">
                     <div class="d-flex justify-content-between align-items-start mb-3">
                         <div>
-                            <h3 class="card-title mb-1">{{ workout.user.username }}</h3>
+                            <h3 class="card-title mb-1">
+                                <a href="{{ url_for('main.user_profile', user_id=workout.user_id) }}" class="text-decoration-none">{{ workout.user.username }}</a>
+                            </h3>
                             <p class="text-muted small mb-0">{{ workout.date.strftime('%d %b %Y %H:%M') }}</p>
                         </div>
 
@@ -78,7 +80,7 @@
                                 {% for comment in workout.comments|sort(attribute='created_at') %}
                                     {# Comment ownership uses user IDs; usernames are only shown as labels. #}
                                     <div class="mb-3 border-bottom pb-2" data-owner-id="{{ comment.user_id }}">
-                                        <strong>{{ comment.user.username }}</strong>
+                                        <strong><a href="{{ url_for('main.user_profile', user_id=comment.user_id) }}" class="text-decoration-none">{{ comment.user.username }}</a></strong>
                                         <span class="text-muted small">{{ comment.created_at.strftime('%d %b %Y %H:%M') }}</span>
                                         <p class="mb-0">{{ comment.text }}</p>
                                     </div>
@@ -99,7 +101,9 @@
                 <div class="card-body">
                     <div class="d-flex justify-content-between align-items-start mb-3">
                         <div>
-                            <h3 class="card-title mb-1">{{ post.user.username }}</h3>
+                            <h3 class="card-title mb-1">
+                                <a href="{{ url_for('main.user_profile', user_id=post.user_id) }}" class="text-decoration-none">{{ post.user.username }}</a>
+                            </h3>
                             <p class="text-muted small mb-0">{{ post.created_at.strftime('%d %b %Y %H:%M') }}</p>
                         </div>
 
@@ -119,7 +123,7 @@
                                 {% for comment in post.comments|sort(attribute='created_at') %}
                                     {# Comment ownership uses user IDs; usernames are only shown as labels. #}
                                     <div class="mb-3 border-bottom pb-2" data-owner-id="{{ comment.user_id }}">
-                                        <strong>{{ comment.user.username }}</strong>
+                                        <strong><a href="{{ url_for('main.user_profile', user_id=comment.user_id) }}" class="text-decoration-none">{{ comment.user.username }}</a></strong>
                                         <span class="text-muted small">{{ comment.created_at.strftime('%d %b %Y %H:%M') }}</span>
                                         <p class="mb-0">{{ comment.text }}</p>
                                     </div>

--- a/app/templates/user_profile.html
+++ b/app/templates/user_profile.html
@@ -1,0 +1,101 @@
+{% extends "base.html" %}
+
+{% block title %}{{ user.username }} – FitTrack{% endblock %}
+
+{% block content %}
+
+    <!-- Profile Hero Card -->
+    <section class="card app-card mb-4">
+        <div class="card-body">
+            <div class="d-flex align-items-center gap-4 flex-wrap">
+                <div class="avatar-placeholder profile-avatar">
+                    {{ user.username[0].upper() }}
+                </div>
+                <div class="flex-grow-1">
+                    <h1 class="section-title mb-1 profile-username" style="font-size: 1.6rem;">{{ user.username }}</h1>
+                    <p class="mb-0" style="color: var(--color-text-faint); font-size: 0.82rem;">
+                        Member since {{ user.created_at.strftime('%B %Y') }}
+                    </p>
+                    {% if user.bio %}
+                        <p class="mt-2 mb-0" style="font-size: 0.92rem; color: var(--color-text-muted);">{{ user.bio }}</p>
+                    {% else %}
+                        <p class="mt-2 mb-0" style="font-size: 0.88rem; color: var(--color-text-faint); font-style: italic;">No bio set.</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Stats Row -->
+    <section class="card app-card mb-4">
+        <div class="card-body">
+            <h2 class="section-title">Activity Summary</h2>
+            <div class="row text-center g-0">
+                <div class="col-4">
+                    <div class="stat-value">{{ workouts | length }}</div>
+                    <div class="stat-label">Public Workouts</div>
+                </div>
+                <div class="col-4 stat-divider">
+                    <div class="stat-value">{{ total_calories_burned | int }}</div>
+                    <div class="stat-label">Calories Burned</div>
+                </div>
+                <div class="col-4 stat-divider">
+                    <div class="stat-value">{{ achievements | length }}</div>
+                    <div class="stat-label">Achievements</div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Public Workouts -->
+    <section class="card app-card mb-4">
+        <div class="card-body">
+            <h2 class="section-title">Public Workouts</h2>
+            {% if workouts %}
+                <ul class="list-unstyled mb-0">
+                    {% for workout in workouts[:5] %}
+                        <li class="metric-row">
+                            <span class="label">{{ workout.title }}</span>
+                            <span class="value" style="font-size: 0.82rem; color: var(--color-text-muted);">
+                                {{ workout.date.strftime('%d %b') }}
+                                {% if workout.duration_mins %}&nbsp;&middot;&nbsp;{{ workout.duration_mins }} min{% endif %}
+                            </span>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <p class="text-muted mb-0">No public workouts yet.</p>
+            {% endif %}
+        </div>
+    </section>
+
+    <!-- Achievements -->
+    <section class="card app-card">
+        <div class="card-body">
+            <h2 class="section-title">Achievements</h2>
+            {% if achievements %}
+                <div id="achievements-list">
+                    {% for achievement in achievements %}
+                        <article class="achievement-item">
+                            <div class="achievement-icon">
+                                {{ achievement.badge_icon or '🏅' }}
+                            </div>
+                            <div>
+                                <div class="achievement-title">{{ achievement.title }}</div>
+                                {% if achievement.description %}
+                                    <div class="achievement-desc">{{ achievement.description }}</div>
+                                {% endif %}
+                                <div style="font-size: 0.78rem; color: var(--color-text-faint); margin-top: 0.2rem;">
+                                    Earned {{ achievement.earned_at.strftime('%d %b %Y') }}
+                                </div>
+                            </div>
+                        </article>
+                    {% endfor %}
+                </div>
+            {% else %}
+                <p class="text-muted mb-0">No achievements yet.</p>
+            {% endif %}
+        </div>
+    </section>
+
+{% endblock %}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,218 @@
+"""
+Authentication tests for FitTrack.
+
+Covers behaviour not already tested in test_routes.py:
+  - password hashing on signup
+  - duplicate email does not insert a second record
+  - new users are not admins by default
+  - signup auto-logs the user in
+  - password check is case-sensitive
+  - password change via /settings (all valid and invalid cases)
+
+Fixtures (app, client, logged_in_client, admin_client) are defined
+in tests/conftest.py. The seeded users are:
+  - test@test.com  / password123  (regular)
+  - admin@test.com / password123  (admin)
+"""
+
+from werkzeug.security import check_password_hash
+
+from app import db
+from app.models import User
+
+
+# ─── REGISTRATION ────────────────────────────────────────────────────────────
+
+class TestRegistration:
+
+    def test_signup_stores_hashed_password_not_plaintext(self, app, client):
+        """The stored password_hash must not equal the original plaintext."""
+        plain = 'securepass99'
+        client.post('/signup', data={
+            'username': 'hashcheck',
+            'email': 'hashcheck@example.com',
+            'password': plain
+        })
+
+        with app.app_context():
+            user = User.query.filter_by(email='hashcheck@example.com').first()
+            assert user is not None
+            assert user.password_hash != plain
+            assert check_password_hash(user.password_hash, plain)
+
+    def test_signup_new_user_is_not_admin(self, app, client):
+        """A user who registers through /signup must not be granted admin."""
+        client.post('/signup', data={
+            'username': 'regularjoe',
+            'email': 'regularjoe@example.com',
+            'password': 'securepass99'
+        })
+
+        with app.app_context():
+            user = User.query.filter_by(email='regularjoe@example.com').first()
+            assert user.is_admin is False
+
+    def test_signup_duplicate_email_does_not_create_second_record(self, app, client):
+        """A duplicate-email attempt must not insert a second User row."""
+        client.post('/signup', data={
+            'username': 'dupeuser',
+            'email': 'test@test.com',   # already seeded
+            'password': 'securepass99'
+        })
+
+        with app.app_context():
+            count = User.query.filter_by(email='test@test.com').count()
+            assert count == 1
+
+    def test_signup_logs_user_in_automatically(self, client):
+        """After a successful signup the user should be redirected to the
+        dashboard, not to login — confirming they were auto-authenticated."""
+        response = client.post('/signup', data={
+            'username': 'autologin',
+            'email': 'autologin@example.com',
+            'password': 'securepass99'
+        }, follow_redirects=False)
+
+        assert response.status_code == 302
+        assert '/dashboard' in response.headers['Location']
+
+
+# ─── LOGIN ───────────────────────────────────────────────────────────────────
+
+class TestLogin:
+
+    def test_login_password_check_is_case_sensitive(self, client):
+        """Passwords are case-sensitive — wrong case must be rejected."""
+        response = client.post('/login', data={
+            'email': 'test@test.com',
+            'password': 'PASSWORD123'    # correct letters, wrong case
+        }, follow_redirects=True)
+
+        assert b'Invalid email or password' in response.data
+
+    def test_login_empty_email_does_not_authenticate(self, client):
+        """Submitting with a blank email must not grant access."""
+        response = client.post('/login', data={
+            'email': '',
+            'password': 'password123'
+        }, follow_redirects=True)
+
+        assert b'Dashboard' not in response.data
+
+    def test_login_empty_password_does_not_authenticate(self, client):
+        """Submitting with a blank password must not grant access."""
+        response = client.post('/login', data={
+            'email': 'test@test.com',
+            'password': ''
+        }, follow_redirects=True)
+
+        assert b'Dashboard' not in response.data
+
+
+# ─── PASSWORD CHANGE (/settings POST) ────────────────────────────────────────
+
+class TestPasswordChange:
+
+    def test_valid_password_change_is_accepted(self, logged_in_client):
+        """Valid current password and matching new passwords should succeed."""
+        response = logged_in_client.post('/settings', data={
+            'current_password': 'password123',
+            'new_password':     'newSecure456',
+            'confirm_password': 'newSecure456'
+        }, follow_redirects=True)
+
+        assert b'Password updated successfully' in response.data
+
+    def test_password_change_updates_hash_in_database(self, app, logged_in_client):
+        """After a successful change the new hash must verify against the new
+        password, and the old password must no longer verify."""
+        logged_in_client.post('/settings', data={
+            'current_password': 'password123',
+            'new_password':     'brandNew789',
+            'confirm_password': 'brandNew789'
+        })
+
+        with app.app_context():
+            user = User.query.filter_by(email='test@test.com').first()
+            assert check_password_hash(user.password_hash, 'brandNew789')
+            assert not check_password_hash(user.password_hash, 'password123')
+
+    def test_wrong_current_password_is_rejected(self, logged_in_client):
+        """Supplying the wrong current password must be refused."""
+        response = logged_in_client.post('/settings', data={
+            'current_password': 'wrongcurrent',
+            'new_password':     'newSecure456',
+            'confirm_password': 'newSecure456'
+        }, follow_redirects=True)
+
+        assert b'Current password is incorrect' in response.data
+
+    def test_mismatched_new_passwords_are_rejected(self, logged_in_client):
+        """new_password and confirm_password that differ must be refused."""
+        response = logged_in_client.post('/settings', data={
+            'current_password': 'password123',
+            'new_password':     'newSecure456',
+            'confirm_password': 'differentNew789'
+        }, follow_redirects=True)
+
+        assert b'New passwords do not match' in response.data
+
+    def test_new_password_same_as_old_is_rejected(self, logged_in_client):
+        """Setting the new password to the same value as the current one
+        must be refused."""
+        response = logged_in_client.post('/settings', data={
+            'current_password': 'password123',
+            'new_password':     'password123',
+            'confirm_password': 'password123'
+        }, follow_redirects=True)
+
+        assert b'New password must be different' in response.data
+
+    def test_password_change_does_not_log_user_out(self, logged_in_client):
+        """A successful password change should keep the current session active."""
+        logged_in_client.post('/settings', data={
+            'current_password': 'password123',
+            'new_password':     'newSecure456',
+            'confirm_password': 'newSecure456'
+        })
+
+        response = logged_in_client.get('/dashboard')
+        assert response.status_code == 200
+
+    def test_old_password_rejected_after_change(self, client):
+        """After a password change, logging in with the old password must fail."""
+        client.post('/login', data={
+            'email': 'test@test.com', 'password': 'password123'
+        })
+        client.post('/settings', data={
+            'current_password': 'password123',
+            'new_password':     'updatedPass99',
+            'confirm_password': 'updatedPass99'
+        })
+        client.get('/logout')
+
+        response = client.post('/login', data={
+            'email':    'test@test.com',
+            'password': 'password123'       # old password
+        }, follow_redirects=True)
+
+        assert b'Invalid email or password' in response.data
+
+    def test_new_password_works_after_change(self, client):
+        """After a password change, logging in with the new password must succeed."""
+        client.post('/login', data={
+            'email': 'test@test.com', 'password': 'password123'
+        })
+        client.post('/settings', data={
+            'current_password': 'password123',
+            'new_password':     'updatedPass99',
+            'confirm_password': 'updatedPass99'
+        })
+        client.get('/logout')
+
+        response = client.post('/login', data={
+            'email':    'test@test.com',
+            'password': 'updatedPass99'     # new password
+        }, follow_redirects=True)
+
+        assert b'Dashboard' in response.data


### PR DESCRIPTION
# Feature: Add other user profile page

## Summary

Adds a public-facing profile page for viewing other users, and wires up
usernames on the friend feed as clickable links.

Closes #108

## Changes

- `app/routes.py` — new `GET /user/<int:user_id>` route. Returns public
  workouts only. Redirects to `/profile` if the requesting user visits
  their own ID.
- `app/templates/user_profile.html` — new read-only template. Shows username,
  bio, member since date, public workouts, achievements, and aggregate stats.
  No email, no body metrics, no edit controls.
- `app/templates/friends_feed.html` — all four username occurrences (workout
  post authors, feed post authors, and their respective comment authors) wrapped
  in links to `/user/<user_id>`.

## Testing

1. Log in and open the friend feed
2. Click any username on a post or comment
3. Verify the public profile page loads with no email, no private workouts, and
   no edit controls
4. Click your own username — verify it redirects to `/profile`
5. Navigate directly to `/user/<invalid_id>` — verify 404