### PR TITLE
Add editable daily calorie burn goal

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -116,11 +116,19 @@ def profile():
     achievements = Achievement.query.filter_by(user_id=current_user.id).all()
     total_calories_burned = sum(w.calories_burned or 0 for w in workouts)
 
+    active_calorie_goal = Goal.query.filter_by(
+        user_id=current_user.id,
+        type='calories',
+        completed=False
+    ).first()
+    daily_calorie_goal = active_calorie_goal.target if active_calorie_goal else 600
+
     return render_template(
         'profile.html',
         workouts=workouts,
         achievements=achievements,
-        total_calories_burned=total_calories_burned
+        total_calories_burned=total_calories_burned,
+        daily_calorie_goal=daily_calorie_goal
     )
 
 
@@ -1588,6 +1596,33 @@ def admin():
     )
 
 # ─── API: EDIT PROFILE ──────────────────────────────────
+def _parse_calorie_goal(raw):
+    """Validate a daily calorie burn goal value. Returns (target, error)."""
+    if raw is None or str(raw).strip() == '':
+        return None, None
+    try:
+        target = int(raw)
+    except (TypeError, ValueError):
+        return None, 'Daily calorie goal must be a whole number.'
+    if target < 1 or target > 10000:
+        return None, 'Daily calorie goal must be between 1 and 10000.'
+    return target, None
+
+
+def _upsert_calorie_goal(user_id, target):
+    """Insert or update the active calorie goal row for the given user."""
+    goal_row = Goal.query.filter_by(
+        user_id=user_id, type='calories', completed=False
+    ).first()
+    if goal_row:
+        goal_row.target = target
+    else:
+        db.session.add(Goal(
+            user_id=user_id, type='calories', target=target,
+            current=0, completed=False
+        ))
+
+
 @main.route('/api/edit-profile', methods=['POST'])
 @login_required
 def api_edit_profile():
@@ -1602,6 +1637,10 @@ def api_edit_profile():
     weight = data.get('weight')
     height = data.get('height')
     goal = (data.get('goal') or '').strip()
+
+    calorie_goal, calorie_err = _parse_calorie_goal(data.get('daily_calorie_goal'))
+    if calorie_err:
+        return jsonify({'success': False, 'error': calorie_err}), 400
 
     # Check username is not already taken by another user
     if username and username != current_user.username:
@@ -1626,9 +1665,26 @@ def api_edit_profile():
             return jsonify({'success': False, 'error': 'Invalid height value.'}), 400
     if goal:
         current_user.goal = goal
+    if calorie_goal is not None:
+        _upsert_calorie_goal(current_user.id, calorie_goal)
 
     db.session.commit()
     return jsonify({'success': True, 'message': 'Profile updated successfully.'})
+
+
+@main.route('/api/calorie-goal', methods=['POST'])
+@login_required
+def api_update_calorie_goal():
+    data = request.get_json(silent=True) or {}
+    target, err = _parse_calorie_goal(data.get('daily_calorie_goal'))
+    if err:
+        return jsonify({'success': False, 'error': err}), 400
+    if target is None:
+        return jsonify({'success': False, 'error': 'Daily calorie goal is required.'}), 400
+
+    _upsert_calorie_goal(current_user.id, target)
+    db.session.commit()
+    return jsonify({'success': True, 'daily_calorie_goal': target})
 
 # ─── OTHER USER PROFILE ─────────────────────────────────
 @main.route('/user/<int:user_id>')

--- a/app/static/profile.js
+++ b/app/static/profile.js
@@ -17,6 +17,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const weight = document.getElementById('edit-weight').value.trim();
         const height = document.getElementById('edit-height').value.trim();
         const goal = document.getElementById('edit-goal').value.trim();
+        const dailyCalorieGoal = document.getElementById('edit-daily-calorie-goal').value.trim();
 
         // Clear previous messages
         const errorBox = document.getElementById('edit-profile-error');
@@ -39,7 +40,10 @@ document.addEventListener('DOMContentLoaded', function () {
         fetch('/api/edit-profile', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ username, bio, weight, height, goal })
+            body: JSON.stringify({
+                username, bio, weight, height, goal,
+                daily_calorie_goal: dailyCalorieGoal
+            })
         })
         .then(response => response.json())
         .then(data => {

--- a/app/templates/calories-page.html
+++ b/app/templates/calories-page.html
@@ -14,9 +14,17 @@
 <section class="calorie-goal-section mb-4">
     <div class="card app-card">
         <div class="card-body">
-            <h2 class="section-title">Active Goal: Calories Burnt</h2>
+            <div class="d-flex justify-content-between align-items-start flex-wrap gap-2">
+                <h2 class="section-title mb-0">Active Goal: Calories Burnt</h2>
+                <button type="button"
+                        class="btn btn-sm btn-outline-primary"
+                        data-bs-toggle="modal"
+                        data-bs-target="#editCalorieGoalModal">
+                    Edit goal
+                </button>
+            </div>
 
-            <p class="text-muted mb-3">
+            <p class="text-muted mb-3 mt-2">
                 Today's Progress: {{ total_calories_burned }} / {{ calorie_burn_goal }} kcal
             </p>
 
@@ -224,6 +232,38 @@
     </div>
 </section>
 
+<!-- Edit calorie goal modal -->
+<div class="modal fade" id="editCalorieGoalModal" tabindex="-1" aria-labelledby="editCalorieGoalModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content" style="background-color: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg);">
+
+            <div class="modal-header" style="border-bottom: 1px solid var(--color-border);">
+                <h5 class="modal-title section-title mb-0" id="editCalorieGoalModalLabel">Edit daily calorie burn goal</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+
+            <div class="modal-body">
+                <div id="edit-calorie-goal-error" class="alert alert-danger" style="display: none;"></div>
+                <div id="edit-calorie-goal-success" class="alert alert-success" style="display: none;"></div>
+
+                <label for="edit-calorie-goal-input" class="form-label">Daily calorie burn goal (kcal)</label>
+                <input type="number" class="form-control" id="edit-calorie-goal-input"
+                       min="1" max="10000" step="1"
+                       value="{{ calorie_burn_goal }}">
+                <p class="text-muted mt-2 mb-0" style="font-size: 0.85rem;">
+                    Allowed range: 1 – 10000 kcal.
+                </p>
+            </div>
+
+            <div class="modal-footer" style="border-top: 1px solid var(--color-border);">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="save-calorie-goal-btn">Save</button>
+            </div>
+
+        </div>
+    </div>
+</div>
+
 <!-- Weekly calories chart -->
 <section class="weekly-calories-section mb-4">
     <div class="card app-card">
@@ -266,4 +306,55 @@
     </script>
 
     <script src="{{ url_for('static', filename='calories.js') }}"></script>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const saveBtn = document.getElementById('save-calorie-goal-btn');
+            if (!saveBtn) return;
+
+            const input = document.getElementById('edit-calorie-goal-input');
+            const errorBox = document.getElementById('edit-calorie-goal-error');
+            const successBox = document.getElementById('edit-calorie-goal-success');
+
+            saveBtn.addEventListener('click', function () {
+                errorBox.style.display = 'none';
+                successBox.style.display = 'none';
+
+                const value = input.value.trim();
+                if (!value) {
+                    errorBox.textContent = 'Please enter a daily calorie goal.';
+                    errorBox.style.display = 'block';
+                    return;
+                }
+
+                saveBtn.disabled = true;
+                saveBtn.textContent = 'Saving...';
+
+                fetch('/api/calorie-goal', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ daily_calorie_goal: value })
+                })
+                .then(r => r.json())
+                .then(data => {
+                    if (data.success) {
+                        successBox.textContent = 'Goal updated. Refreshing…';
+                        successBox.style.display = 'block';
+                        setTimeout(() => window.location.reload(), 800);
+                    } else {
+                        errorBox.textContent = data.error || 'Could not update goal.';
+                        errorBox.style.display = 'block';
+                    }
+                })
+                .catch(() => {
+                    errorBox.textContent = 'Network error. Please try again.';
+                    errorBox.style.display = 'block';
+                })
+                .finally(() => {
+                    saveBtn.disabled = false;
+                    saveBtn.textContent = 'Save';
+                });
+            });
+        });
+    </script>
 {% endblock %}

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -181,6 +181,14 @@
                            placeholder="e.g. Lose 5kg, Run a marathon"
                            value="{{ current_user.goal or '' }}">
                 </div>
+
+                <div class="mb-3">
+                    <label for="edit-daily-calorie-goal" class="form-label">Daily calorie burn goal (kcal)</label>
+                    <input type="number" class="form-control" id="edit-daily-calorie-goal"
+                           min="1" max="10000" step="1"
+                           placeholder="600"
+                           value="{{ daily_calorie_goal }}">
+                </div>
             </div>
 
             <div class="modal-footer" style="border-top: 1px solid var(--color-border);">


### PR DESCRIPTION
## Summary
- Adds a "Daily calorie burn goal (kcal)" field to the Edit Profile modal so users can set their goal from the profile page
- Adds an "Edit goal" button on `/calories` that opens a modal to update the goal inline
- New `POST /api/calorie-goal` endpoint plus shared validation/upsert helpers; `/api/edit-profile` now also upserts the goal
- Default for users with no goal stays at 600 kcal (no DB migration — uses existing `Goal` table with `type='calories'`)
