### PR TITLE
Add CSRF token to meal deletion

### DIFF
--- a/app/static/js/calories.js
+++ b/app/static/js/calories.js
@@ -138,7 +138,10 @@ document.addEventListener('DOMContentLoaded', function () {
         }
 
         fetch(`/api/delete-meal/${mealId}`, {
-            method: 'DELETE'
+            method: 'DELETE',
+            headers: {
+                'X-CSRFToken': csrfToken
+            }
         })
         .then(response => response.json())
         .then(data => {


### PR DESCRIPTION
Fixed AJAX meal deletion by sending the CSRF token with the delete request.

## Changes made

- Added the `X-CSRFToken` header to the delete meal `fetch()` request.
- Fixed the `400 BAD REQUEST` error when deleting meals after CSRF protection was enabled.

## Testing

- Verified that meals can be deleted successfully.
- Verified that deleting a meal updates the page without refreshing.
- Verified that the previous JSON parsing error no longer appears.